### PR TITLE
Fix SQL soundness proof graph test

### DIFF
--- a/Veritas/src/test/scala/de/tu_darmstadt/veritas/VerificationInfrastructure/SQLSoundnessProofGraph.scala
+++ b/Veritas/src/test/scala/de/tu_darmstadt/veritas/VerificationInfrastructure/SQLSoundnessProofGraph.scala
@@ -50,7 +50,7 @@ class SQLSoundnessProofGraph(file: File) {
   val rootobl = g.findObligation("SQL progress").get
   val rootobl_edge_map = applyInductionGetCases(rootobl, MetaVar("q"))
 
-  val rootcasenames = rootobl_edge_map.keys.toSeq.sortWith(_ < _)
+  val rootcasenames = rootobl_edge_map.keys.toSeq.sortWith(_ > _)
 
   //apply simply Solve-tactic to t-value base case
   val tvaluecaseobl = rootobl_edge_map(rootcasenames(0))._1


### PR DESCRIPTION
The obligations in rootcasenames were in the wrong order which caused the test to fail.

With ``<``, the returned order is *SQL-ProgressDifference,SQL-ProgressIntersection,SQL-ProgressUnion,SQL-ProgressselectFromWhere,SQL-Progresstvalue*.

But the subsequent code assumes *SQL-Progresstvalue,SQL-ProgressselectFromWhere,SQL-ProgressUnion,SQL-ProgressIntersection,SQL-ProgressDifference* which is exactly the order of ``rootcasenames`` if ``<`` is replaced by ``>``.