### PR TITLE
Fix PreservationProperty typo in DSK builder

### DIFF
--- a/Veritas/src/main/scala/de/tu_darmstadt/veritas/scalaspl/dsk/DomainSpecificKnowledgeBuilder.scala
+++ b/Veritas/src/main/scala/de/tu_darmstadt/veritas/scalaspl/dsk/DomainSpecificKnowledgeBuilder.scala
@@ -53,7 +53,7 @@ trait DomainSpecificKnowledgeBuilder[Specification <: ScalaSPLSpecification with
       if(ScalaMetaUtils.containsAnnotation(fn.mods, "Recursive"))
         collectRecursive(fn)
       progressProperties ++= collectLinkingAnnotation(fn, "ProgressProperty")(collect)
-      preservationProperties ++= collectLinkingAnnotation(fn, "PreservationPoperty")(collect)
+      preservationProperties ++= collectLinkingAnnotation(fn, "PreservationProperty")(collect)
     case tr: Defn.Trait =>
       if (ScalaMetaUtils.containsAnnotation(tr.mods, "FailableType"))
         failableTypes += tr


### PR DESCRIPTION
This fixes the collection of preservation properties for functions.