### PR TITLE
Update SQLSpec progress and preservation lemmas

### DIFF
--- a/Veritas/src/test/scala/de/tu_darmstadt/veritas/scalaspl/SQLSpec.scala
+++ b/Veritas/src/test/scala/de/tu_darmstadt/veritas/scalaspl/SQLSpec.scala
@@ -827,11 +827,11 @@ object SQLSpec extends ScalaSPLSpecification {
   } ensuring welltypedRawtable(tt2, rt2)
 
   @Property
-  def projectTableWelltypedWithSelectType(sel: Select, t: Table, tt: TType, tt2: TType): Unit = {
+  def projectTableWelltypedWithSelectType(sel: Select, t: Table, t2: Table, tt: TType, tt2: TType): Unit = {
     require(welltypedtable(tt, t))
     require(projectType(sel, tt) == someTType(tt2))
-  } ensuring exists((t2: Table) => projectTable(sel, t) == someTable(t2)) ensuring welltypedtable(
-    tt2, getTable(projectTable(sel, t))) // TODO: how to wrap this?
+    require(projectTable(sel, t) == someTable(t2))
+  } ensuring welltypedtable(tt2, t2)
 
   @Property
   def reducePreservation(ttc: TTContext, ts: TStore, q: Query, qr: Query, tt: TType): Unit = {

--- a/Veritas/src/test/scala/de/tu_darmstadt/veritas/scalaspl/SQLSpec.scala
+++ b/Veritas/src/test/scala/de/tu_darmstadt/veritas/scalaspl/SQLSpec.scala
@@ -43,10 +43,6 @@ object SQLSpec extends ScalaSPLSpecification {
 
   case class ttcons(n: Name, ft: FType, tt: TType) extends TType
 
-  def getFirstName(tt: TType): Name = tt match {
-    case ttcons(n, _, _) => n
-  }
-
   def appendTTypes(tt1: TType, tt2: TType): TType = (tt1, tt2) match {
     case (ttempty(), tt) => tt
     case (ttcons(name, ft, tttail1), tt) => ttcons(name, ft, appendTTypes(tttail1, tt))

--- a/Veritas/src/test/scala/de/tu_darmstadt/veritas/scalaspl/SQLSpec.scala
+++ b/Veritas/src/test/scala/de/tu_darmstadt/veritas/scalaspl/SQLSpec.scala
@@ -70,31 +70,6 @@ object SQLSpec extends ScalaSPLSpecification {
     case tcons(_, rttail) => succ(rawTableLength(rttail))
   }
 
-  def onlyRowsWithSingleColumn(rt: RawTable): Boolean = rt match {
-    case tempty() => true
-    case tcons(rcons(_, rempty()), rttail) => onlyRowsWithSingleColumn(rttail)
-    case _ => false
-  }
-
-  def onlyNonemptyRows(rt: RawTable): Boolean = rt match {
-    case tempty() => true
-    case tcons(rcons(_, _), rttail) => onlyNonemptyRows(rttail)
-    case _ => false
-  }
-
-  def onlyRowsMatchingAttrLength(rt: RawTable, al: AttrL): Boolean = rt match {
-    case tempty() => true
-    case tcons(row, rttail) => rowLength(row) == attrListLength(al) && onlyRowsMatchingAttrLength(rttail, al)
-  }
-
-  // this will only work if both tables have the same row count
-  def onlyRowsWithDecrementedLength(decremented: RawTable, original: RawTable): Boolean = (decremented, original) match {
-    case (tempty(), tempty()) => true
-    case (tcons(r1, rt1), tcons(r2, rt2)) =>
-      succ(rowLength(r1)) == rowLength(r2) && onlyRowsWithDecrementedLength(rt1, rt2)
-    case _ => false
-  }
-
   // full table with "header" (attribute list)
   sealed trait Table extends Expression
 
@@ -385,7 +360,7 @@ object SQLSpec extends ScalaSPLSpecification {
 
   @ProgressProperty("findColTypeImpliesfindCol")
   // TODO: maybe also projectTypeImpliesFindCol?
-  @PreservationProperty("projectTypeFindCol")
+  @PreservationProperty("findColPreservesWelltypedRaw")
   // TODO: maybe also findColPreservesRowCount?
   def findCol(n: Name, attrL: AttrL, rt: RawTable): OptRawTable = (n, attrL, rt) match {
     case (a, aempty(), _) => noRawTable()
@@ -717,7 +692,8 @@ object SQLSpec extends ScalaSPLSpecification {
 
   @Property
   def projectColsProgress(tt: TType, al: AttrL, rt: RawTable, al2: AttrL, tt2: TType): Unit = {
-    require(welltypedtable(tt, table(al, rt)))
+    require(welltypedRawtable(tt, rt))
+    require(matchingAttrL(tt, al))
     require(projectType(list(al2), tt) == someTType(tt2))
   } ensuring exists((rt2: RawTable) => projectCols(al2, al, rt) == someRawTable(rt2))
 
@@ -725,14 +701,16 @@ object SQLSpec extends ScalaSPLSpecification {
          from the conclusion to the premise. */
   @Property
   def projectTypeImpliesFindCol(tt: TType, al: AttrL, rt: RawTable, al2: AttrL, tt2: TType, n: Name): Unit = {
-    require(welltypedtable(tt, table(al, rt)))
+    require(welltypedRawtable(tt, rt))
+    require(matchingAttrL(tt, al))
     require(projectTypeAttrL(al2, tt) == someTType(tt2))
     attrIn(n, al2)
   } ensuring exists((rt2: RawTable) => findCol(n, al, rt) == someRawTable(rt2))
 
   @Property
   def findColTypeImpliesfindCol(tt: TType, al: AttrL, rt: RawTable, n: Name, ft: FType): Unit = {
-    require(welltypedtable(tt, table(al, rt)))
+    require(welltypedRawtable(tt, rt))
+    require(matchingAttrL(tt, al))
     require(findColType(n, tt) == someFType(ft))
   } ensuring exists((rt2: RawTable) => findCol(n, al, rt) == someRawTable(rt2))
 
@@ -783,18 +761,18 @@ object SQLSpec extends ScalaSPLSpecification {
   } ensuring welltypedRawtable(ttempty(), projectEmptyCol(rt))
 
   @Property
-  def projectFirstRawPreservesWelltypedRaw(a: Name, t: Table, tt: TType, tt2: TType, ft: FType, tt3: TType): Unit = {
+  def projectFirstRawPreservesWelltypedRaw(a: Name, t: Table, tt: TType, ct: FType, ttrest: TType): Unit = {
+    require(tt == ttcons(a, ct, ttrest))
     require(welltypedRawtable(tt, getRaw(t)))
-    require(projectTypeAttrL(acons(a, aempty()), tt) == someTType(tt2))
-    require(tt == ttcons(a, ft, tt3))
-  } ensuring welltypedRawtable(tt2, projectFirstRaw(getRaw(t)))
+  } ensuring welltypedRawtable(ttcons(a, ct, ttempty()), projectFirstRaw(getRaw(t)))
 
   @Property
-  def projectTypeFindCol(a: Name, t: table, tt: TType, tt2: TType, rt: RawTable): Unit = {
-    require(welltypedtable(tt, t))
-    require(projectTypeAttrL(acons(a, aempty()), tt) == someTType(tt2))
-    require(findCol(a, getAttrL(t), getRaw(t)) == someRawTable(rt))
-  } ensuring welltypedRawtable(tt2, rt)
+  def findColPreservesWelltypedRaw(a: Name, al: AttrL, rt: RawTable, tt: TType, ft: FType, rt2: RawTable): Unit = {
+    require(welltypedRawtable(tt, rt))
+    require(matchingAttrL(tt, al))
+    require(findColType(a, tt) == someFType(ft))
+    require(findCol(a, al, rt) == someRawTable(rt2))
+  } ensuring welltypedRawtable(ttcons(a, ft, ttempty()), rt2)
 
   @Property
   def attachColToFrontRawPreservesWellTypedRaw(tt1: TType, name1: Name, ft1: FType,
@@ -805,13 +783,14 @@ object SQLSpec extends ScalaSPLSpecification {
     require(rawTableLength(rt1) == rawTableLength(rt2))
     require(welltypedRawtable(tt1, rt1))
     require(welltypedRawtable(tt1, rt2))
-  } ensuring welltypedRawtable(ttcons(name1, ft1, tt2), attachColToFrontRaw(rt1, rt2)) ensuring // TODO: how to wrap this?
-    rawTableLength(rt1) == rawTableLength(attachColToFrontRaw(rt1, rt2)) // TODO: isn't this the lemma below?
+  } ensuring welltypedRawtable(ttcons(name1, ft1, tt2), attachColToFrontRaw(rt1, rt2))
 
   @Property
-  def attachColToFrontRawPreservesRowCount(rt1: RawTable, rt2: RawTable): Unit = {
+  def attachColToFrontRawPreservesRowCount(tt1: TType, a: Name, ct: FType,
+                                           rt1: RawTable, rt2: RawTable): Unit = {
+    require(tt1 == ttcons(a, ct, ttempty()))
+    require(welltypedRawtable(tt1, rt1))
     require(rawTableLength(rt1) == rawTableLength(rt2))
-    onlyRowsWithSingleColumn(rt1)
   } ensuring rawTableLength(rt1) == rawTableLength(attachColToFrontRaw(rt1, rt2))
 
   @Property
@@ -828,38 +807,24 @@ object SQLSpec extends ScalaSPLSpecification {
   } ensuring rawTableLength(rt) == rawTableLength(rt2)
 
   @Property
-  def projectFirstRawYieldsSingleColumn(rt: RawTable): Unit = {
-    require(onlyNonemptyRows(rt))
-  } ensuring onlyRowsWithSingleColumn(projectFirstRaw(rt))
-
-  @Property
-  def dropFirstColRawDecrementsColCount(rt: RawTable): Unit = {
-    require(rawTableLength(rt) == rawTableLength(dropFirstColRaw(rt)))
-    require(onlyNonemptyRows(rt))
-  } ensuring onlyRowsWithDecrementedLength(dropFirstColRaw(rt), rt)
-
-  @Property
-  def findColYieldsSingleColumn(a: Name, al: AttrL, rt: RawTable, rt2: RawTable): Unit = {
-    require(findCol(a, al, rt) == someRawTable(rt2))
-    require(onlyRowsMatchingAttrLength(rt, al))
-  } ensuring onlyRowsWithSingleColumn(rt2)
-
-  @Property
   def projectEmptyColPreservesRowCount(rt: RawTable): Unit = {
   } ensuring rawTableLength(rt) == rawTableLength(projectEmptyCol(rt))
 
   @Property
-  def projectColsPreservesRowCount(al1: AttrL, al2: AttrL, rt: RawTable, rt2: RawTable): Unit = {
+  def projectColsPreservesRowCount(tt: TType, tt2: TType, al1: AttrL, al2: AttrL, rt: RawTable, rt2: RawTable): Unit = {
+    require(projectTypeAttrL(al1, tt) == someTType(tt2))
     require(projectCols(al1, al2, rt) == someRawTable(rt2))
-    require(onlyRowsMatchingAttrLength(rt, al2))
+    require(welltypedRawtable(tt, rt))
+    require(matchingAttrL(tt, al2))
   } ensuring rawTableLength(rt) == rawTableLength(rt2)
 
   @Property
-  def projectColsWelltypedWithSelectType(al: AttrL, t: Table, tt: TType, tt2: TType, rt: RawTable): Unit = {
-    require(welltypedtable(tt, t))
+  def projectColsWelltypedWithSelectType(al: AttrL, tal: AttrL, rt: RawTable, rt2: RawTable, tt: TType, tt2: TType): Unit = {
+    require(welltypedRawtable(tt, rt))
+    require(matchingAttrL(tt, tal))
     require(projectTypeAttrL(al, tt) == someTType(tt2))
-    require(projectCols(al, getAttrL(t), getRaw(t)) == someRawTable(rt))
-  } ensuring welltypedRawtable(tt2, rt)
+    require(projectCols(al, tal, rt) == someRawTable(rt2))
+  } ensuring welltypedRawtable(tt2, rt2)
 
   @Property
   def projectTableWelltypedWithSelectType(sel: Select, t: Table, tt: TType, tt2: TType): Unit = {

--- a/Veritas/src/test/scala/de/tu_darmstadt/veritas/scalaspl/SQLSpec.scala
+++ b/Veritas/src/test/scala/de/tu_darmstadt/veritas/scalaspl/SQLSpec.scala
@@ -624,7 +624,7 @@ object SQLSpec extends ScalaSPLSpecification {
 
   //axioms on behavior of table type context
   @Axiom
-  def TTTContextDublicate(x: Name, y: Name, Tx: TType, Ty: TType, C: TTContext, e: Query, T: TType): Unit = {
+  def TTTContextDuplicate(x: Name, y: Name, Tx: TType, Ty: TType, C: TTContext, e: Query, T: TType): Unit = {
     require(x == y)
     require(bindContext(x, Tx, bindContext(y, Ty, C)) |- e :: T)
   } ensuring (bindContext(x, Tx, C) |- e :: T)
@@ -636,8 +636,8 @@ object SQLSpec extends ScalaSPLSpecification {
   } ensuring(bindContext(y, Ty, bindContext(x, Tx, C)) |- e :: T)
 
   @Axiom
-  def Ttvalue(tt: TType, al: AttrL, rt: RawTable, TTC: TTContext, TT: TType): Unit = {
-    require(welltypedtable(tt, table(al, rt)))
+  def Ttvalue(al: AttrL, rt: RawTable, TTC: TTContext, TT: TType): Unit = {
+    require(welltypedtable(TT, table(al, rt)))
   } ensuring(TTC |- tvalue(table(al, rt)) :: TT)
 
   @Axiom

--- a/Veritas/src/test/scala/de/tu_darmstadt/veritas/scalaspl/SQLSpec.scala
+++ b/Veritas/src/test/scala/de/tu_darmstadt/veritas/scalaspl/SQLSpec.scala
@@ -43,11 +43,6 @@ object SQLSpec extends ScalaSPLSpecification {
 
   case class ttcons(n: Name, ft: FType, tt: TType) extends TType
 
-  def appendTTypes(tt1: TType, tt2: TType): TType = (tt1, tt2) match {
-    case (ttempty(), tt) => tt
-    case (ttcons(name, ft, tttail1), tt) => ttcons(name, ft, appendTTypes(tttail1, tt))
-  }
-
   // Value for a field (underspecified)
   trait Val extends Expression
 
@@ -810,7 +805,7 @@ object SQLSpec extends ScalaSPLSpecification {
     require(rawTableLength(rt1) == rawTableLength(rt2))
     require(welltypedRawtable(tt1, rt1))
     require(welltypedRawtable(tt1, rt2))
-  } ensuring welltypedRawtable(appendTTypes(tt1, tt2), attachColToFrontRaw(rt1, rt2)) ensuring // TODO: how to wrap this?
+  } ensuring welltypedRawtable(ttcons(name1, ft1, tt2), attachColToFrontRaw(rt1, rt2)) ensuring // TODO: how to wrap this?
     rawTableLength(rt1) == rawTableLength(attachColToFrontRaw(rt1, rt2)) // TODO: isn't this the lemma below?
 
   @Property

--- a/Veritas/src/test/scala/de/tu_darmstadt/veritas/scalaspl/SQLSpec.scala
+++ b/Veritas/src/test/scala/de/tu_darmstadt/veritas/scalaspl/SQLSpec.scala
@@ -821,19 +821,23 @@ object SQLSpec extends ScalaSPLSpecification {
     require(onlyNonemptyRows(rt))
   } ensuring onlyRowsWithDecrementedLength(dropFirstColRaw(rt), rt)
 
+  @Property
   def findColYieldsSingleColumn(a: Name, al: AttrL, rt: RawTable): Unit = {
     require(isSomeRawTable(findCol(a, al, rt)))
     require(onlyRowsMatchingAttrLength(rt, al))
   } ensuring onlyRowsWithSingleColumn(getRawTable(findCol(a, al, rt)))
 
+  @Property
   def projectEmptyColPreservesRowCount(rt: RawTable): Unit = {
   } ensuring rawTablesSameLength(rt, projectEmptyCol(rt))
 
+  @Property
   def projectColsPreservesRowCount(al1: AttrL, al2: AttrL, rt: RawTable): Unit = {
     require(isSomeRawTable(projectCols(al1, al2, rt)))
     require(onlyRowsMatchingAttrLength(rt, al2))
   } ensuring rawTablesSameLength(rt, getRawTable(projectCols(al1, al2, rt)))
 
+  @Property
   def projectColsWelltypedWithSelectType(al: AttrL, t: Table, tt: TType): Unit = {
     require(welltypedtable(tt, t))
     require(isSomeTType(projectTypeAttrL(al, tt)))
@@ -841,6 +845,7 @@ object SQLSpec extends ScalaSPLSpecification {
   } ensuring welltypedRawtable(getTType(projectTypeAttrL(al, tt)),
                                getRawTable(projectCols(al, getAttrL(t), getRaw(t))))
 
+  @Property
   def projectTableWelltypedWithSelectType(sel: Select, t: Table, tt: TType): Unit = {
     require(welltypedtable(tt, t))
     require(isSomeTType(projectType(sel, tt)))


### PR DESCRIPTION
This translates the progress and preservation lemmas from the current SQL-Dafny type soundness proof to ScalaSPL and also adds some domain-specific annotations.